### PR TITLE
Added readthedocs.io Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This system allows the users to drag and drop Arduino components from the left p
 
 ![Arduino Demo](demo/demo-arduino.gif)
 
+## Documentation 
+
+The latest version of documentation for the project is maintained on [esim-cloud.readthedocs.io](https://esim-cloud.readthedocs.io/)
+
 ## Installation
 
 ### Basic Setup


### PR DESCRIPTION
It was difficult finding the documentation from the docs build status badge, added a heading for it.

Additionally, the readthedocs.io link can be added to the right sidebar of the repo in the 'about section' under the 'website' heading. 
![Screenshot 2021-02-12 at 11 18 30 AM](https://user-images.githubusercontent.com/11258286/107734702-0d0ae480-6d24-11eb-98f9-bf22950ee2df.png)

Somone with admin access can do it. CC: @fresearchgroup @firuza 
