### PR TITLE
Breadboard delete bug fix

### DIFF
--- a/ArduinoFrontend/src/app/Libs/General.ts
+++ b/ArduinoFrontend/src/app/Libs/General.ts
@@ -379,7 +379,8 @@ export class BreadBoard extends CircuitElement {
   onOtherComponentDrag(element) {
     const bBox = this.elements.getBBox();
     const elementBBox = element.elements.getBBox();
-
+    // Disable Node Bubble on hover
+    Point.showBubbleBool = false;
     this.resetHighlightedPoints();
 
     if (!areBoundingBoxesIntersecting(bBox, elementBBox)) {
@@ -410,6 +411,8 @@ export class BreadBoard extends CircuitElement {
    * Listener to handle when dragging of a component stops
    */
   onOtherComponentDragStop() {
+    // Enable Node Bubble on hover
+    Point.showBubbleBool = true;
     // if no highlighted points when the dragging stops, return
     if (this.highlightedPoints.length === 0) {
       return;

--- a/ArduinoFrontend/src/app/Libs/General.ts
+++ b/ArduinoFrontend/src/app/Libs/General.ts
@@ -320,8 +320,8 @@ export class BreadBoard extends CircuitElement {
    */
   constructor(public canvas: any, x: number, y: number) {
     super('BreadBoard', x, y, 'Breadboard.json', canvas);
-    this.subsribeToDrag(this.onOtherComponentDrag.bind(this));
-    this.subscribeToDragStop(this.onOtherComponentDragStop.bind(this));
+    this.subsribeToDrag({ id: this.id, fn: this.onOtherComponentDrag.bind(this) });
+    this.subscribeToDragStop({ id: this.id, fn: this.onOtherComponentDragStop.bind(this) });
   }
 
   /**

--- a/ArduinoFrontend/src/app/Libs/Point.ts
+++ b/ArduinoFrontend/src/app/Libs/Point.ts
@@ -12,6 +12,11 @@ declare var window;
  * Class For Circuit Node ie. Point wires can connect with nodes
  */
 export class Point {
+
+  /**
+   * Boolean to either show bubble on hover or not
+   */
+  static showBubbleBool = true;
   /**
    * Hide node on creation
    */
@@ -106,17 +111,25 @@ export class Point {
 
     // Set Hover callback
     this.body.hover((evt: MouseEvent) => {
-      // Check if callback is present if it is then call it
-      if (this.hoverCallback) {
-        this.hoverCallback(this.x, this.y);
+      // Check if showBubbleBool is enabled
+      if (Point.showBubbleBool) {
+        // Check if callback is present if it is then call it
+        if (this.hoverCallback) {
+          this.hoverCallback(this.x, this.y);
+        }
+        window.showBubble(this.label, evt.clientX, evt.clientY);
+      } else {
+        // TODO: Do not show node highligtht
+        this.remainHidden();
       }
-      window.showBubble(this.label, evt.clientX, evt.clientY);
     }, () => {
       // Check if close callback is present if present call it
       if (this.hoverCloseCallback) {
         this.hoverCloseCallback(this.x, this.y);
       }
       window.hideBubble();
+      // Show node highligtht
+      this.remainShow();
     });
 
     // TODO: Remove The following code After Development

--- a/ArduinoFrontend/src/app/Libs/Workspace.ts
+++ b/ArduinoFrontend/src/app/Libs/Workspace.ts
@@ -790,16 +790,22 @@ export class Workspace {
 
       // If BreadBoard remove draglistners too
       if (key === 'BreadBoard') {
+        // Search in DragListeners & splice
         for (const i in window['DragListeners']) {
-          let itrFn = window['DragListeners'][i]
-          if (itrFn.id === window['Selected'].id) {
-            window['DragListeners'].splice(i, 1)
+          if (window.DragListeners.hasOwnProperty(i)) {
+            const itrFn = window['DragListeners'][i];
+            if (itrFn.id === window['Selected'].id) {
+              window['DragListeners'].splice(i, 1);
+            }
           }
         }
+        // Search in DragStopListeners & splice
         for (const i in window['DragStopListeners']) {
-          let itrFn = window['DragStopListeners'][i]
-          if (itrFn.id === window['Selected'].id) {
-            window['DragStopListeners'].splice(i, 1)
+          if (window.DragStopListeners.hasOwnProperty(i)) {
+            const itrFn = window['DragStopListeners'][i];
+            if (itrFn.id === window['Selected'].id) {
+              window['DragStopListeners'].splice(i, 1);
+            }
           }
         }
       }

--- a/ArduinoFrontend/src/app/Libs/Workspace.ts
+++ b/ArduinoFrontend/src/app/Libs/Workspace.ts
@@ -145,7 +145,7 @@ export class Workspace {
    */
   static onDragStopEvent(element) {
     for (const fn of window.DragStopListeners) {
-      fn(element);
+      fn.fn(element);
     }
   }
 
@@ -154,7 +154,7 @@ export class Workspace {
    */
   static onDragEvent(element) {
     for (const fn of window.DragListeners) {
-      fn(element);
+      fn.fn(element);
     }
   }
 
@@ -785,6 +785,22 @@ export class Workspace {
           window.Selected.remove();
           window.Selected = null;
           window.isSelected = false;
+        }
+      }
+
+      // If BreadBoard remove draglistners too
+      if (key === 'BreadBoard') {
+        for (const i in window['DragListeners']) {
+          let itrFn = window['DragListeners'][i]
+          if (itrFn.id === window['Selected'].id) {
+            window['DragListeners'].splice(i, 1)
+          }
+        }
+        for (const i in window['DragStopListeners']) {
+          let itrFn = window['DragStopListeners'][i]
+          if (itrFn.id === window['Selected'].id) {
+            window['DragStopListeners'].splice(i, 1)
+          }
         }
       }
 


### PR DESCRIPTION
This PR **fixes** Issue #309 

**Changes done:**
1. added **id** attribute in dragListener which can be used to identify breadboard
2. upon deletion added a condition for breadboard to **delete specific dragListener** associated with the deleted element.