### PR TITLE
Fixed the 'no library called "cairo" was found' error

### DIFF
--- a/.github/workflows/angularTestBuild.yml
+++ b/.github/workflows/angularTestBuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Use Node js

--- a/.github/workflows/devDockerCompose.yml
+++ b/.github/workflows/devDockerCompose.yml
@@ -18,14 +18,14 @@ jobs:
 
     - name: Build the docker-compose stack
       run: |
-        docker-compose -f docker-compose.dev.yml --env-file .env pull --ignore-pull-failures
-        docker-compose -f docker-compose.dev.yml --env-file .env build
+        docker compose -f docker-compose.dev.yml --env-file .env pull --ignore-pull-failures
+        docker compose -f docker-compose.dev.yml --env-file .env build
 
     - name: Run the docker-compose step
-      run: docker-compose -f docker-compose.dev.yml --env-file .env up -d
+      run: docker compose -f docker-compose.dev.yml --env-file .env up -d
 
     - name: Check running containers
       run: docker ps -a
 
     - name: Publish images
-      run: docker-compose -f docker-compose.dev.yml --env-file .env push
+      run: docker compose -f docker-compose.dev.yml --env-file .env push

--- a/.github/workflows/devDockerCompose.yml
+++ b/.github/workflows/devDockerCompose.yml
@@ -9,7 +9,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/dockerTestBackend.yml
+++ b/.github/workflows/dockerTestBackend.yml
@@ -20,8 +20,8 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${{ github.repository_owner }} --password-stdin
     - name: Build Images
       run: |
-        docker-compose -f docker-compose.dev.yml --env-file .env pull --ignore-pull-failures
-        docker-compose -f docker-compose.dev.yml --env-file .env build
+        docker compose -f docker-compose.dev.yml --env-file .env pull --ignore-pull-failures
+        docker compose -f docker-compose.dev.yml --env-file .env build
     - name: Run Django Test Suite
       run: |
-        docker-compose -f docker-compose.dev.yml run django python manage.py test
+        docker compose -f docker-compose.dev.yml run django python manage.py test

--- a/.github/workflows/dockerTestBackend.yml
+++ b/.github/workflows/dockerTestBackend.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/masterDockerCompose.yml
+++ b/.github/workflows/masterDockerCompose.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/masterDockerCompose.yml
+++ b/.github/workflows/masterDockerCompose.yml
@@ -18,15 +18,15 @@ jobs:
     - name: Build the docker-compose stack
       run: |
         cp .env .env.prod
-        docker-compose -f docker-compose.prod.yml --env-file .env.prod pull --ignore-pull-failures
-        docker-compose -f docker-compose.prod.yml --env-file .env.prod build
+        docker compose -f docker-compose.prod.yml --env-file .env.prod pull --ignore-pull-failures
+        docker compose -f docker-compose.prod.yml --env-file .env.prod build
 
     - name: Run the docker-compose step
-      run: docker-compose -f docker-compose.prod.yml --env-file .env.prod up -d
+      run: docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
 
     - name: Check running containers
       run: docker ps -a
 
     - name: Publish images
       if: github.ref == 'refs/heads/master'
-      run: docker-compose -f docker-compose.prod.yml --env-file .env.prod push
+      run: docker compose -f docker-compose.prod.yml --env-file .env.prod push

--- a/.github/workflows/prodContainers.yml
+++ b/.github/workflows/prodContainers.yml
@@ -15,13 +15,13 @@ jobs:
     - name: Build the docker-compose stack
       run: |
         cp .env .env.prod
-        docker-compose -f docker-compose.prod.yml --env-file .env.prod pull --ignore-pull-failures
-        docker-compose -f docker-compose.prod.yml --env-file .env.prod build
+        docker compose -f docker-compose.prod.yml --env-file .env.prod pull --ignore-pull-failures
+        docker compose -f docker-compose.prod.yml --env-file .env.prod build
     - name: Run the docker-compose step
-      run: docker-compose -f docker-compose.prod.yml --env-file .env.prod up -d
+      run: docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
 
     - name: Check running containers
       run: docker ps -a
 
     - name: Publish images
-      run: docker-compose -f docker-compose.prod.yml --env-file .env.prod push
+      run: docker compose -f docker-compose.prod.yml --env-file .env.prod push

--- a/.github/workflows/prodContainers.yml
+++ b/.github/workflows/prodContainers.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Login to docker

--- a/.github/workflows/reactEslint.yml
+++ b/.github/workflows/reactEslint.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   eslint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: darshkpatel/eslint-action@master

--- a/.github/workflows/reactTestBuild.yml
+++ b/.github/workflows/reactTestBuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Use Node js

--- a/esim-cloud-backend/Dockerfile
+++ b/esim-cloud-backend/Dockerfile
@@ -33,6 +33,7 @@ RUN curl -fSL https://github.com/imr/ngspice/archive/ngspice-$NGSPICE_VERSION.ta
 
 # Arduino Cli and Compiling tools
 RUN apk add \
+	cairo-dev cairo cairo-tools \
         wget \
         tar \
         ca-certificates \

--- a/esim-cloud-backend/Dockerfile
+++ b/esim-cloud-backend/Dockerfile
@@ -33,14 +33,16 @@ RUN curl -fSL https://github.com/imr/ngspice/archive/ngspice-$NGSPICE_VERSION.ta
 
 # Arduino Cli and Compiling tools
 RUN apk add \
-	cairo-dev cairo cairo-tools \
         wget \
         tar \
         ca-certificates \
         gcc-avr \
         binutils \
         avr-libc \
-        ctags
+        ctags \
+        cairo-dev \
+        cairo \
+        cairo-tools
 
 ENV USER=root
 

--- a/first_run.dev.sh
+++ b/first_run.dev.sh
@@ -15,16 +15,16 @@ export COMPOSE_HTTP_TIMEOUT=120
 
 #Build Containers
 echo 'Building Containers, might take a while'
-docker-compose -f docker-compose.dev.yml --env-file .env build
+docker compose -f docker-compose.dev.yml --env-file .env build
 
 # MYSQL does not play well with other containers if not allowed to finish config beforehand
 echo 'Waiting for DB to finish its thing....'
-docker-compose -f docker-compose.dev.yml --no-recreate --env-file .env -d up db
+docker compose -f docker-compose.dev.yml --no-recreate --env-file .env -d up db
 echo 'Waiting for 1 Minute'
 sleep 1m
 
 echo 'Applying Database Migrations'
-docker-compose -f docker-compose.dev.yml --env-file .env run --rm django /bin/sh migrations.sh
+docker compose -f docker-compose.dev.yml --env-file .env run --rm django /bin/sh migrations.sh
 
 echo 'Copying Pre-Defined eSim-Gallery'
 if [ ! -d esim-cloud-backend/file_storage ]; then

--- a/first_run.dev.sh
+++ b/first_run.dev.sh
@@ -15,16 +15,16 @@ export COMPOSE_HTTP_TIMEOUT=120
 
 #Build Containers
 echo 'Building Containers, might take a while'
-docker compose -f docker-compose.dev.yml --env-file .env build
+docker-compose -f docker-compose.dev.yml --env-file .env build
 
 # MYSQL does not play well with other containers if not allowed to finish config beforehand
 echo 'Waiting for DB to finish its thing....'
-docker compose -f docker-compose.dev.yml --no-recreate --env-file .env -d up db
+docker-compose -f docker-compose.dev.yml --no-recreate --env-file .env -d up db
 echo 'Waiting for 1 Minute'
 sleep 1m
 
 echo 'Applying Database Migrations'
-docker compose -f docker-compose.dev.yml --env-file .env run --rm django /bin/sh migrations.sh
+docker-compose -f docker-compose.dev.yml --env-file .env run --rm django /bin/sh migrations.sh
 
 echo 'Copying Pre-Defined eSim-Gallery'
 if [ ! -d esim-cloud-backend/file_storage ]; then


### PR DESCRIPTION
This PR addresses the error: Original OSError: no library called "cairo" was found, which occurs when the required Cairo graphics library is not installed or properly configured in the system. This created a problem in loading the Gallery in the eSim on CLoud and Arduino on Cloud. It also created problems in loading the components in eSim on Cloud.

The following screenshot shows the issue that was arising earlier while running `./first_run.dev.sh`:
![image](https://github.com/user-attachments/assets/7c5ea8c0-6c11-42f0-9a8c-bbaf19f5df90)

The issue is fixed by adding a command in the docker script to install the cairo libraries.
