### PR TITLE
UI bug slideswitch fix

### DIFF
--- a/ArduinoFrontend/src/app/Libs/inputs/Buttons.ts
+++ b/ArduinoFrontend/src/app/Libs/inputs/Buttons.ts
@@ -223,6 +223,7 @@ export class SlideSwitch extends CircuitElement {
    */
   constructor(public canvas: any, x: number, y: number) {
     super('SlideSwitch', x, y, 'SlideSwitch.json', canvas);
+    this.setDragListeners();
   }
   /**
    * Initialize Slide Switch

--- a/ArduinoFrontend/src/app/Libs/inputs/Buttons.ts
+++ b/ArduinoFrontend/src/app/Libs/inputs/Buttons.ts
@@ -283,6 +283,7 @@ export class SlideSwitch extends CircuitElement {
    */
   closeSimulation(): void {
     this.elements.unclick();
+    this.elements.undrag();
     this.setDragListeners();
     this.setClickListener(null);
     const anim = Raphael.animation({ transform: `t${this.tx},${this.ty}` }, 500);


### PR DESCRIPTION
The slide switch gets detached from the wire when the simulation is stopped and the switch is dragged while clicking. To reproduce the issue:
- Move the slide switch around.
- Simulate and then stop the simulation.
- When dragging and clicking the slide switch, it becomes detached from the wire.
 